### PR TITLE
Expanded image view

### DIFF
--- a/client/app.css
+++ b/client/app.css
@@ -64,21 +64,22 @@ header {
 }
 
 header nav {
-  text-align: left;
+  height: 4rem;
   background-color: rgb(4, 4, 4);
+  text-align: left;
   color: lightgray;
 }
 
 header nav h1 {
-  margin: 0;
-  margin-bottom: 4px;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  column-gap: 1em;
+  padding-left: 1rem;
 }
 
 header nav img {
-  height: 40px;
-  width: 110px;
-  margin: 4px 8px;
-  vertical-align: middle;
+  height: 2em;
 }
 
 header p {
@@ -86,11 +87,6 @@ header p {
   font-weight: 300;
   font-size: small;
   text-transform: uppercase;
-}
-
-.o-product-overview {
-  border: solid gray 1px;
-  padding: 8px;
 }
 
 .qaDisplay {

--- a/client/overview/CartActions.jsx
+++ b/client/overview/CartActions.jsx
@@ -44,10 +44,14 @@ function CartActions(props) {
   } else {
     return (
       <section className="o-cart-actions">
-        <SelectSize inventory={inventory} saveSize={saveOrderSize} />
-        <SelectQty inventory={inventory} saveQty={saveOrderQty} selectedSize={orderSize} />
-        <button>Add to bag</button>
-        <button>&#9734;</button>
+        <section className="o-cart-lists">
+          <SelectSize inventory={inventory} saveSize={saveOrderSize} />
+          <SelectQty inventory={inventory} saveQty={saveOrderQty} selectedSize={orderSize} />
+        </section>
+        <section className="o-cart-buttons">
+          <button className="o-add-to-bag">Add to bag<span className="o-add-to-bag-icon">+</span></button>
+          <button className="o-add-to-outfit">&#9734;</button>
+        </section>
       </section>
     );
   }

--- a/client/overview/ImageGallery.jsx
+++ b/client/overview/ImageGallery.jsx
@@ -146,9 +146,8 @@ class ImageGallery extends React.Component {
       )
     } else {
       return (
-        <section className="o-images">
-          <img
-            className={
+        <section className={this.props.imageMode === 0 ? "o-images" : "o-images o-expanded"}>
+          <img className={
               this.props.imageMode === 0
                 ? "o-images-main pointer"
                 : this.props.imageMode === 1

--- a/client/overview/ImageGallery.jsx
+++ b/client/overview/ImageGallery.jsx
@@ -25,8 +25,6 @@ class ImageGallery extends React.Component {
       this.setState({
         isLoaded: false
       });
-
-
       this.setImages(this.state.selectedImageIndex);
     }
   }
@@ -58,7 +56,24 @@ class ImageGallery extends React.Component {
 
     // main image click
     if (classes.contains('o-images-main')) {
-      this.props.toggleExpandedMode();
+
+      let newMode;
+      if (this.props.imageMode === 0) {
+        newMode = 1; //normal --> expanded
+      }
+      // delete after zoom view is coded
+      if (this.props.imageMode === 1) {
+        newMode = 0; //expanded --> normal
+      }
+
+      // comment out until zoom view is coded
+      // if (this.props.imageMode === 1) {
+      //   newMode = 2; //expanded --> zoomed
+      // }
+      // if (this.props.imageMode === 2) {
+      //   newMode = 1; //zoomed --> expanded
+      // }
+      this.props.setImageMode(newMode);
       return;
     }
 
@@ -132,7 +147,17 @@ class ImageGallery extends React.Component {
     } else {
       return (
         <section className="o-images">
-          <img className="o-images-main pointer" src={this.state.mainImageUrl} onClick={this.handleClick} />
+          <img
+            className={
+              this.props.imageMode === 0
+                ? "o-images-main pointer"
+                : this.props.imageMode === 1
+                  ? "o-images-main o-expanded pointer"
+                  : "o-images-main o-zoomed pointer"
+            }
+            src={this.state.mainImageUrl}
+            onClick={this.handleClick}
+          />
           <nav className="o-images-thumbnails">
             {this.renderThumbnailGallery()}
           </nav>

--- a/client/overview/ImageGallery.jsx
+++ b/client/overview/ImageGallery.jsx
@@ -12,7 +12,7 @@ class ImageGallery extends React.Component {
     this.handleClick = this.handleClick.bind(this);
     this.setImages = this.setImages.bind(this);
 
-    // helpful values not needed in state
+    // helpful values (not needed in state)
     this.thumbnailsToShow = 7;
   }
 
@@ -29,6 +29,7 @@ class ImageGallery extends React.Component {
     }
   }
 
+  // calculates which thumbnails to show (when there are more than the max allowed) and sets state
   setImages(selectedImageIndex) {
 
     // "quantize" the input - if the provided index is out of bounds, bound it
@@ -50,6 +51,7 @@ class ImageGallery extends React.Component {
     });
   }
 
+  // a single click handler for everything on the page; uses classes to determine what was clicked
   handleClick(e) {
 
     let classes = e.currentTarget.classList;
@@ -80,7 +82,7 @@ class ImageGallery extends React.Component {
     // thumbnail gallery clicks
     let newSelectedImageIndex = 0;
 
-    if (classes.contains('o-images-thumbnail')) {
+    if ( classes.contains('o-images-thumbnail') || classes.contains('o-images-thumbnail-icon') ) {
       newSelectedImageIndex = parseInt(e.currentTarget.id);
     }
     if (classes.contains('back-arrow')) {
@@ -93,6 +95,7 @@ class ImageGallery extends React.Component {
 
   }
 
+  // renders the two versions of the thumbnail gallery (want to make this a subcomonent)
   renderThumbnailGallery() {
 
     if(!this.props.stylePhotos || this.props.stylePhotos.length === 1) { return null };
@@ -100,31 +103,64 @@ class ImageGallery extends React.Component {
     const firstVisibleImageIndex = this.state.topImageIndex;
     const lastVisibleImageIndex = firstVisibleImageIndex + this.thumbnailsToShow - 1;
 
-    // render the thumbnail gallery
-    let thumbnailList = this.props.stylePhotos.map((photo, index) => {
-      let imgClass = 'pointer o-images-thumbnail ';
-      if (index === this.state.selectedImageIndex) { imgClass = imgClass + 'o-images-selected' };
-      imgClass = imgClass.trim();
+    let thumbnailList;
+    let imgClass;
+    let isSelected;
 
-      if (index >= firstVisibleImageIndex && index <= lastVisibleImageIndex) {
+    // render the thumbnail gallery
+
+    // render the normal view - images
+    if (this.props.imageMode === 0) {
+      thumbnailList = this.props.stylePhotos.map((photo, index) => {
+
+        isSelected = index === this.state.selectedImageIndex;
+        imgClass = 'pointer o-images-thumbnail';
+        if (isSelected) { imgClass = imgClass + ' ' + 'o-images-selected' };
+        imgClass = imgClass.trim();
+
+        if (index >= firstVisibleImageIndex && index <= lastVisibleImageIndex) {
+          if (this.props.imageMode === 0) {
+            return (
+              <li key={index}>
+                <img id={index} className={imgClass} src={photo.thumbnail_url} onClick={this.handleClick} />
+              </li>
+            )
+          }
+        }
+      });
+    }
+
+    // render the expanded view (icons)
+    if (this.props.imageMode === 1) {
+      thumbnailList = this.props.stylePhotos.map((photo, index) => {
+        isSelected = index === this.state.selectedImageIndex;
         return (
           <li key={index}>
-            <img id={index} className={imgClass} src={photo.thumbnail_url} onClick={this.handleClick} />
+            <svg viewBox="0 0 100 100" width="100%" height="100%">
+              <circle cx="50" cy="50" r="35" className="o-images-thumbnail-icon pointer" id={index} onClick={this.handleClick} />
+              { isSelected
+                  ? <circle cx="50" cy="50" r="25" className="o-images-thumbnail-icon selected pointer" id={index} onClick={this.handleClick} />
+                  : null
+              }
+            </svg>
           </li>
         )
-      }
-    });
+      });
+
+    }
 
     // render the forward/backward arrows
     let backArrow = null;
     let forwardArrow = null;
 
-    if (firstVisibleImageIndex > 0) {
-      backArrow = (<i className='pointer back-arrow' onClick={this.handleClick}></i>);
-    }
+    if (this.props.imageMode === 0) {
+      if (firstVisibleImageIndex > 0) {
+        backArrow = (<i className='pointer back-arrow' onClick={this.handleClick}></i>);
+      }
 
-    if (lastVisibleImageIndex < this.props.stylePhotos.length - 1) {
-      forwardArrow = (<i className='pointer forward-arrow' onClick={this.handleClick}></i>);
+      if (lastVisibleImageIndex < this.props.stylePhotos.length - 1) {
+        forwardArrow = (<i className='pointer forward-arrow' onClick={this.handleClick}></i>);
+      }
     }
 
     // return elements

--- a/client/overview/ImageGallery.jsx
+++ b/client/overview/ImageGallery.jsx
@@ -55,6 +55,14 @@ class ImageGallery extends React.Component {
   handleClick(e) {
 
     let classes = e.currentTarget.classList;
+
+    // main image click
+    if (classes.contains('o-images-main')) {
+      this.props.toggleExpandedMode();
+      return;
+    }
+
+    // thumbnail gallery clicks
     let newSelectedImageIndex = 0;
 
     if (classes.contains('o-images-thumbnail')) {
@@ -124,7 +132,7 @@ class ImageGallery extends React.Component {
     } else {
       return (
         <section className="o-images">
-          <img className="o-images-main" src={this.state.mainImageUrl} />
+          <img className="o-images-main pointer" src={this.state.mainImageUrl} onClick={this.handleClick} />
           <nav className="o-images-thumbnails">
             {this.renderThumbnailGallery()}
           </nav>

--- a/client/overview/Overview.jsx
+++ b/client/overview/Overview.jsx
@@ -148,13 +148,16 @@ class Overview extends React.Component {
             stylePhotos={this.state.selectedStyle.photos}
             toggleExpandedMode={this.toggleExpandedMode}
           />
-          <ProductControls
-            product={this.state.product}
-            styles={this.state.productStyles}
-            selectedStyleId={this.state.selectedStyleId}
-            style={this.state.selectedStyle}
-            setStyle={this.setStyle}
-          />
+          { this.state.expandedMode
+            ? null
+            : <ProductControls
+                product={this.state.product}
+                styles={this.state.productStyles}
+                selectedStyleId={this.state.selectedStyleId}
+                style={this.state.selectedStyle}
+                setStyle={this.setStyle}
+              />
+          }
           <ProductDescription product={this.state.product} />
         </section>
       );

--- a/client/overview/Overview.jsx
+++ b/client/overview/Overview.jsx
@@ -17,12 +17,14 @@ class Overview extends React.Component {
       productStyles: [],
       selectedStyleId: null,
       selectedStyle: null,
+      expandedMode: false,
       productLoaded: false,
       styleLoaded: false,
       useMockData: false
     }
 
     this.setStyle = this.setStyle.bind(this);
+    this.toggleExpandedMode = this.toggleExpandedMode.bind(this);
   }
 
   componentDidMount() {
@@ -124,6 +126,12 @@ class Overview extends React.Component {
     }
   }
 
+  toggleExpandedMode() {
+    this.setState({
+      expandedMode: !this.state.expandedMode
+    })
+  }
+
   render() {
 
     if (!this.state.productLoaded || !this.state.styleLoaded) {
@@ -135,7 +143,11 @@ class Overview extends React.Component {
     } else {
       return (
         <section className="o-product-overview">
-          <ImageGallery selectedStyleId={this.state.selectedStyleId} stylePhotos={this.state.selectedStyle.photos} />
+          <ImageGallery
+            selectedStyleId={this.state.selectedStyleId}
+            stylePhotos={this.state.selectedStyle.photos}
+            toggleExpandedMode={this.toggleExpandedMode}
+          />
           <ProductControls
             product={this.state.product}
             styles={this.state.productStyles}

--- a/client/overview/Overview.jsx
+++ b/client/overview/Overview.jsx
@@ -17,14 +17,14 @@ class Overview extends React.Component {
       productStyles: [],
       selectedStyleId: null,
       selectedStyle: null,
-      expandedMode: false,
+      imageMode: 0,
       productLoaded: false,
       styleLoaded: false,
       useMockData: false
     }
 
     this.setStyle = this.setStyle.bind(this);
-    this.toggleExpandedMode = this.toggleExpandedMode.bind(this);
+    this.setImageMode = this.setImageMode.bind(this);
   }
 
   componentDidMount() {
@@ -126,9 +126,10 @@ class Overview extends React.Component {
     }
   }
 
-  toggleExpandedMode() {
+  setImageMode(mode) {
+    // 0: normal, 1: expanded, 2: zoomed
     this.setState({
-      expandedMode: !this.state.expandedMode
+      imageMode: mode
     })
   }
 
@@ -146,9 +147,10 @@ class Overview extends React.Component {
           <ImageGallery
             selectedStyleId={this.state.selectedStyleId}
             stylePhotos={this.state.selectedStyle.photos}
-            toggleExpandedMode={this.toggleExpandedMode}
+            imageMode={this.state.imageMode}
+            setImageMode={this.setImageMode}
           />
-          { this.state.expandedMode
+          { this.state.imageMode > 0
             ? null
             : <ProductControls
                 product={this.state.product}

--- a/client/overview/ProductDescription.jsx
+++ b/client/overview/ProductDescription.jsx
@@ -19,11 +19,15 @@ const ProductDescription = (props) => {
   } else {
     return (
       <section className="o-product-description">
-        <p className="o-product-description-slogan">{props.product[0].slogan}</p>
-        <p className="o-product-description-text">{props.product[0].description}</p>
-        <ul className="o-product-description-features">
-          {renderFeatures()}
-        </ul>
+        <section className="o-product-description-text">
+          <p className="o-product-description-slogan">{props.product[0].slogan}</p>
+          <p className="o-product-description-text">{props.product[0].description}</p>
+        </section>
+        <section className="o-product-description-features">
+          <ul className="o-product-description-bullets">
+            {renderFeatures()}
+          </ul>
+        </section>
       </section>
     );
   }

--- a/client/overview/overview.css
+++ b/client/overview/overview.css
@@ -238,8 +238,6 @@ a[href], input[type='submit'], input[type='image'], label[for], select, button, 
   width: 5rem;
 }
 
-
-
 /* PRODUCT DESCRIPTION */
 
 .o-product-description-slogan {
@@ -260,4 +258,13 @@ a[href], input[type='submit'], input[type='image'], label[for], select, button, 
   font-family: 'Material Icons';
   position: relative;
   left: -0.7rem;
+}
+
+/* STATE STYLES
+- - - - - - - - - - - - - - - - - - - - - - - - */
+
+/* EXPANDED VIEW */
+
+.o-images.o-expanded {
+  max-width: 100%;
 }

--- a/client/overview/overview.css
+++ b/client/overview/overview.css
@@ -36,7 +36,9 @@ a[href], input[type='submit'], input[type='image'], label[for], select, button, 
   /* ↓ The width when the left and right are on the same row */
   flex-basis: 50rem;
   flex-grow: 1;
-  max-width: 60rem;
+  /* max-width: 50rem; */
+  max-width: 100%;
+  position: relative;
 }
 
 .o-product-controls {
@@ -45,35 +47,77 @@ a[href], input[type='submit'], input[type='image'], label[for], select, button, 
   flex-grow: 999;
   /* ↓ Wrap when the right side is smaller than this */
   min-width: 20rem;
+
+  margin-top: 1rem;
+  margin-left: 0.8rem;
 }
+
+.o-cart-lists {
+  width: 100%;
+  display: flex;
+}
+
+.o-size-list {
+ flex-grow: 1.6;
+}
+
+.o-qty-list {
+  flex-grow: 1;
+}
+
+.o-cart-buttons {
+  width: 100%;
+  display: flex;
+}
+
+.o-add-to-bag {
+  flex-grow: 10;
+  text-align: left;
+}
+
+.o-add-to-outfit {
+  flex-grow: 1;
+}
+
+.o-add-to-bag-icon {
+  float: right;
+}
+
 
 .o-product-description {
   /* ↓ Grow from... */
   flex-basis: 100%;
+  max-width: 1000px;
+  margin: auto;
+  margin-bottom: 3rem;
+
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
 }
 
-.o-images {
-  position: relative;
+.o-product-description-text {
+  max-width: 45rem;
+  min-width: 20rem;
 }
 
 .o-images-thumbnails {
-  width: 3.25rem;
   position: absolute;
-  top: 0.7rem;
+  top: 1rem;
   left: 1rem;
 }
+
 
 
 /* MODULE STYLES
 - - - - - - - - - - - - - - - - - - - - - - - - */
 
-
 /* IMAGE GALLERY */
 
 .o-images-main {
   width: 100%;
-  max-height: 30rem;
-  min-height: 30rem;
+  max-height: 39rem;
+  min-height: 39rem;
   object-fit: cover;
 }
 
@@ -86,15 +130,25 @@ a[href], input[type='submit'], input[type='image'], label[for], select, button, 
   list-style-type: none;
 }
 
+.o-images-thumbnails ul li {
+  width: 4.2rem;
+  height: 4.2rem;
+  margin: 0.6rem 0;
+}
+
 .o-images-thumbnails img {
-  width: 3.25rem;
-  height: 3.25rem;
+  width: 100%;
+  height: 100%;
   object-fit: cover;
-  border: solid Black 0.05rem;
+  border: solid black 0.05rem;
 }
 
 .o-images nav img.o-images-selected {
-  border-color: White;
+  border-color: white;
+}
+
+.o-images-thumbnails img:hover {
+  border: solid grey 0.05rem;
 }
 
 .back-arrow-container,
@@ -118,24 +172,32 @@ a[href], input[type='submit'], input[type='image'], label[for], select, button, 
 }
 
 .back-arrow {
-  border-bottom: 0.75rem solid gray;
+  border-bottom: 0.75rem solid #DBDBDB;
 }
 
 .forward-arrow {
-  border-top: 0.75rem solid gray;
+  border-top: 0.75rem solid #DBDBDB;
 }
+
 
 
 /* PRODUCT CONTROLS */
 
+.o-product-controls.stars {
+  margin-bottom: 1rem;
+}
+
 .o-product-category {
   font-weight: 100;
   text-transform: uppercase;
+  margin-bottom: 0.5rem;
 }
 
 .o-product-name {
   font-size: 2rem;
   font-weight: 700;
+  margin-top: 0rem;
+  margin-bottom: 0rem;
 }
 
 .o-product-style-price .strikethrough {
@@ -147,12 +209,17 @@ a[href], input[type='submit'], input[type='image'], label[for], select, button, 
   color: red;
 }
 
+
+/* PRODUCT CONTROLS: STYLE SELECTOR */
+
 .o-style-selector {
   display: flex;
   flex-wrap: wrap;
-  width: 100%;
+  width: 99%;
   row-gap: 1.5rem;
   column-gap: 2rem;
+
+  margin: 2rem 0rem;
 }
 
 .circle-container {
@@ -172,16 +239,16 @@ a[href], input[type='submit'], input[type='image'], label[for], select, button, 
   position: relative;
   width: 100%;
 
-  -webkit-box-shadow: 0.1rem 0.1rem 0.3rem 0.1rem #ccc;
-  -moz-box-shadow:    0.1rem 0.1rem 0.3rem 0.1rem #ccc;
-  box-shadow:         0.1rem 0.1rem 0.3rem 0.1rem #ccc;
+  -webkit-box-shadow: 0.05rem 0.05rem 0.1rem 0.05rem #3D3D3D;
+  -moz-box-shadow:    0.05rem 0.05rem 0.1rem 0.05rem #3D3D3D;
+  box-shadow:         0.05rem 0.05rem 0.1rem 0.05rem #3D3D3D;
   /* [horizontal offset] [vertical offset] [blur radius] [optional spread radius] [color]; */
 }
 
 .circle:hover {
-  -webkit-box-shadow: 0.1rem 0.1rem 0.3rem 0.1rem #141414;
-  -moz-box-shadow:    0.1rem 0.1rem 0.3rem 0.1rem #141414;
-  box-shadow:         0.1rem 0.1rem 0.3rem 0.1rem #141414;
+  -webkit-box-shadow: 0.1rem 0.1rem 0.25rem 0.1rem #141414;
+  -moz-box-shadow:    0.1rem 0.1rem 0.25rem 0.1rem #141414;
+  box-shadow:         0.1rem 0.1rem 0.25rem 0.1rem #141414;
 }
 
 .circle::after {
@@ -219,8 +286,6 @@ a[href], input[type='submit'], input[type='image'], label[for], select, button, 
   z-index: 1;
   position: absolute;
   left: 3rem;
-
-
 }
 
 .circle-container .icon-container .material-icons {
@@ -234,37 +299,62 @@ a[href], input[type='submit'], input[type='image'], label[for], select, button, 
   left: -0.17rem;
 }
 
-.o-qty-list {
-  width: 5rem;
-}
+
+/* PRODUCT CONTROLS: ADD TO CART CONTROLS */
+
+
+
+
 
 /* PRODUCT DESCRIPTION */
 
 .o-product-description-slogan {
-  font-size: medium;
+  font-size: 1.1rem;
   font-weight: bold;
 }
 
 .o-product-description-features {
-  list-style: none;
+  border-left: solid black 0.1rem;
 }
 
-.o-product-description-features li {
+
+.o-product-description-bullets li {
   list-style: none;
+  line-height: 2rem;
+  margin-left: 0;
 }
 
-.o-product-description-features li::before {
+.o-product-description-bullets li::before {
   content: "\E876";
   font-family: 'Material Icons';
   position: relative;
   left: -0.7rem;
 }
 
-/* STATE STYLES
+
+/* STATE-RELATED STYLES
 - - - - - - - - - - - - - - - - - - - - - - - - */
 
-/* EXPANDED VIEW */
+/* EXPANDED VIEW STYLES */
 
 .o-images.o-expanded {
   max-width: 100%;
+}
+
+.o-images.o-expanded nav ul li {
+  width: 1.5rem;
+  height: 1.5rem;
+  text-align: center;
+}
+
+.o-images-thumbnail-icon {
+  fill-opacity: 0.5;
+  fill: white;
+  stroke: black;
+  stroke-width: 0.35rem;
+}
+
+.o-images-thumbnail-icon.selected {
+  fill-opacity: 0.9;
+  fill: black;
 }


### PR DESCRIPTION
- Clicking the main image expands to fill the width of the page
- Thumbnails are replaced with icons (with the selected image's icon differentiated)
- Style selection circles now max out at 4 per row
- Made some visual changes to more closely match the page mockups
  - Increased the main image height to ~630px
  - Moved feature bullets to the right side and added a horizontal border
  - Put the cart-related buttons into two flex boxes and styled accordingly
  - Increased the header height and changed how it centers

Note:
- Clicking the expanded image (for now) will shrink it again. In the next rev, it will open into zoom mode.
